### PR TITLE
Handle non-JSON responses from document upload API

### DIFF
--- a/src/app/admin/document-upload/page.tsx
+++ b/src/app/admin/document-upload/page.tsx
@@ -121,11 +121,22 @@ export default function DocumentUploadPage() {
 
       clearInterval(progressInterval);
       setUploadProgress(100);
-      
-      const responseData = await response.json();
+
+      const contentType = response.headers.get("content-type");
+      const isJsonResponse = contentType?.includes("application/json");
+
+      let responseData: any = null;
+
+      if (isJsonResponse) {
+        responseData = await response.json();
+      } else {
+        const errorText = await response.text();
+        const fallbackMessage = errorText || `HTTP error! status: ${response.status}`;
+        throw new Error(fallbackMessage);
+      }
 
       if (!response.ok) {
-        throw new Error(responseData.error || `HTTP error! status: ${response.status}`);
+        throw new Error(responseData?.error || `HTTP error! status: ${response.status}`);
       }
 
       toast({


### PR DESCRIPTION
## Summary
- guard the document upload form submission against non-JSON API responses
- surface the raw response text when the upload endpoint does not return JSON so admins receive actionable errors

## Testing
- npm run lint *(fails: pre-existing lint violations in src/components/document-list.tsx and a react-hooks warning)*

------
https://chatgpt.com/codex/tasks/task_b_68e412c2669c8323a937fbbaecc856f6