### PR TITLE
Improve login authentication flow and restrict Word uploads to admins

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,45 +1,154 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/use-auth";
-import { AppLogo } from "@/components/app-logo";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { LogIn } from "lucide-react";
+import { LogIn, ShieldCheck } from "lucide-react";
+
+import { AppLogo } from "@/components/app-logo";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import LoadingDots from "@/components/ui/loading-dots";
 
 export default function LoginPage() {
-  const { loginAsAdmin, loginAsClient } = useAuth();
   const router = useRouter();
+  const { login, user, loading } = useAuth();
 
-  const handleAdminLogin = () => {
-    loginAsAdmin();
-    router.push("/admin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!loading && user) {
+      const destination = user.role === "admin" ? "/admin" : "/dashboard";
+      router.replace(destination);
+    }
+  }, [loading, router, user]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      await login({ email, password });
+    } catch (authError) {
+      const message =
+        authError instanceof Error
+          ? authError.message
+          : "Unable to sign in. Please verify your credentials.";
+      setErrorMessage(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
-  const handleClientLogin = () => {
-    loginAsClient();
-    router.push("/dashboard");
-  };
+  const isBusy = loading || isSubmitting;
+
+  const credentialHints = useMemo(
+    () => [
+      {
+        label: "Admin",
+        email: "ruan@sitesafety.services",
+        password: "Admin@123",
+      },
+      {
+        label: "Client",
+        email: "client@example.com",
+        password: "Client@123",
+      },
+      {
+        label: "Consultant",
+        email: "consultant@example.com",
+        password: "Consult@123",
+      },
+    ],
+    []
+  );
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center">
             <AppLogo />
           </div>
           <CardTitle>Welcome to RAK-SMS</CardTitle>
           <CardDescription>
-            Select a role to sign in.
+            Sign in with your organisation credentials to continue.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <Button onClick={handleAdminLogin} className="w-full">
-            <LogIn className="mr-2 h-4 w-4" /> Log In as Admin
-          </Button>
-          <Button onClick={handleClientLogin} variant="secondary" className="w-full">
-            <LogIn className="mr-2 h-4 w-4" /> Log In as Client
-          </Button>
+        <CardContent className="space-y-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2 text-left">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+                disabled={isBusy}
+              />
+            </div>
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                disabled={isBusy}
+              />
+            </div>
+            {errorMessage ? (
+              <Alert variant="destructive">
+                <AlertDescription>{errorMessage}</AlertDescription>
+              </Alert>
+            ) : null}
+            <Button type="submit" className="w-full" disabled={isBusy}>
+              {isSubmitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <LoadingDots />
+                  <span>Signing in...</span>
+                </span>
+              ) : (
+                <>
+                  <LogIn className="mr-2 h-4 w-4" /> Sign In
+                </>
+              )}
+            </Button>
+          </form>
+          <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            <p className="mb-2 font-medium text-foreground">Test credentials</p>
+            <ul className="space-y-1 text-left">
+              {credentialHints.map((item) => (
+                <li key={item.label}>
+                  <span className="font-semibold text-foreground">{item.label}:</span>{" "}
+                  {item.email} / {item.password}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 flex items-center gap-2 text-xs">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Microsoft Word uploads are restricted to administrators only.
+            </p>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/document-list.tsx
+++ b/src/components/document-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+import { Timestamp } from "firebase/firestore";
 import {
   Table,
   TableBody,
@@ -22,23 +23,64 @@ import type { Document } from "@/types/documents";
 // Helper function to render a document icon based on its type
 const DocumentIcon = ({ type }: { type?: string }) => {
   if (!type) return <File className="h-4 w-4 text-gray-400" />;
-  if (type.includes("pdf")) return <FileText className="h-4 w-4 text-red-600" />;
-  if (type.includes("spreadsheet") || type.includes("excel")) return <File className="h-4 w-4 text-green-600" />;
-  if (type.includes("zip") || type.includes("cad")) return <File className="h-4 w-4 text-yellow-600" />;
-  return <File className="h-4 w-4 text-blue-600" />;
+  const lowercaseType = type.toLowerCase();
+  if (lowercaseType.includes("pdf")) {
+    return <FileText className="h-4 w-4 text-red-600" />;
+  }
+  if (lowercaseType.includes("spreadsheet") || lowercaseType.includes("excel")) {
+    return <File className="h-4 w-4 text-green-600" />;
+  }
+  if (lowercaseType.includes("word")) {
+    return <File className="h-4 w-4 text-blue-600" />;
+  }
+  if (lowercaseType.includes("zip") || lowercaseType.includes("cad")) {
+    return <File className="h-4 w-4 text-yellow-600" />;
+  }
+  return <File className="h-4 w-4 text-slate-500" />;
 };
 
+const now = Timestamp.fromDate(new Date());
+
 const mockDocuments: Document[] = [
-    { id: "1", name: "General Risk Assessment.pdf", category: "Safety", section: "Risk Assessments", subSection: "General", url: "#", type: "pdf", updatedAt: new Date() as any, version: '1' },
-    { id: "2", name: "Working at Height Permit.docx", category: "Safety", section: "Permits", subSection: "Work Permits", url: "#", type: "docx", updatedAt: new Date() as any, version: '1' },
-    { id: "3", name: "QMS Manual.pdf", category: "Quality", section: "Manuals", url: "#", type: "pdf", updatedAt: new Date() as any, version: '1' },
+  {
+    id: "1",
+    name: "General Risk Assessment.pdf",
+    category: "Safety",
+    section: "Risk Assessments",
+    subSection: "General",
+    url: "#",
+    type: "application/pdf",
+    updatedAt: now,
+    version: "1",
+  },
+  {
+    id: "2",
+    name: "Working at Height Permit.docx",
+    category: "Safety",
+    section: "Permits",
+    subSection: "Work Permits",
+    url: "#",
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    updatedAt: now,
+    version: "1",
+  },
+  {
+    id: "3",
+    name: "QMS Manual.pdf",
+    category: "Quality",
+    section: "Manuals",
+    url: "#",
+    type: "application/pdf",
+    updatedAt: now,
+    version: "1",
+  },
 ];
 
 // DocumentList component to display documents for a specific category
 export function DocumentList({ category }: { category: string }) {
   const [openSections, setOpenSections] = useState<string[]>([]);
 
-  const documents = mockDocuments.filter(doc => doc.category === category);
+  const documents = mockDocuments.filter((doc) => doc.category === category);
 
   const groupedBySection = useMemo(() => {
     return documents.reduce((acc, doc) => {
@@ -91,14 +133,16 @@ export function DocumentList({ category }: { category: string }) {
                               <DocumentIcon type={doc.type} />
                               <span className="truncate">{doc.name}</span>
                             </div>
-                            {(doc.status !== 'processing' && (doc.url || doc.downloadURL)) ? (
+                            {doc.status !== "processing" && (doc.url || doc.downloadURL) ? (
                               <Button variant="ghost" size="sm" asChild>
                                 <a href={doc.url || doc.downloadURL} target="_blank" rel="noopener noreferrer" download={doc.name}>
                                   <Download className="mr-2 h-4 w-4" /> Download
                                 </a>
                               </Button>
                             ) : (
-                              <span className="text-sm text-muted-foreground">{doc.status}...</span>
+                              <span className="text-sm text-muted-foreground">
+                                {doc.status ? `${doc.status}…` : "Processing…"}
+                              </span>
                             )}
                           </li>
                         ))}

--- a/src/components/document-list.tsx
+++ b/src/components/document-list.tsx
@@ -53,7 +53,9 @@ export function DocumentList({ category }: { category: string }) {
       <div className="text-center p-10 text-muted-foreground">
         <FileText className="h-12 w-12 mx-auto mb-4" />
         <p className="font-semibold">No Documents Found</p>
-        <p className="text-sm">There are no documents in the '{category}' category.</p>
+        <p className="text-sm">
+          There are no documents in the &lsquo;{category}&rsquo; category.
+        </p>
       </div>
     );
   }
@@ -68,7 +70,7 @@ export function DocumentList({ category }: { category: string }) {
     >
       {Object.entries(groupedBySection).map(([section, sectionDocs]) => {
         const groupedBySubSection = sectionDocs.reduce((acc, doc) => {
-          const subSection = doc.subSection || 'General';
+          const subSection = doc.subSection || "General";
           (acc[subSection] = acc[subSection] || []).push(doc);
           return acc;
         }, {} as Record<string, Document[]>);


### PR DESCRIPTION
## Summary
- replace the role toggle login screen with a credential-based sign-in form that surfaces helpful feedback and redirects by role
- centralize hardcoded user accounts in the auth context with proper validation and persistence helpers
- tighten document upload validation so only admins can submit Word files and refresh supporting copy and lint issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e3f462d7bc832387db04847f06780f